### PR TITLE
Fix Zookeeper Cluster Readiness Check in init container

### DIFF
--- a/charts/stardog/templates/statefulset.yaml
+++ b/charts/stardog/templates/statefulset.yaml
@@ -82,12 +82,10 @@ spec:
         {{- if .Values.zookeeper.enabled }}
             while :
               do
-              echo "Checking for ZK followers"
-              ZK_MNTR=$(echo mntr | nc {{ .Release.Name }}-zookeeper-headless.{{ .Release.Namespace }} 2181)
-              ZK_FOLLOWERS=$(echo "${ZK_MNTR}" | grep zk_synced_followers | awk '{print $2}')
-              echo "Currently ${ZK_FOLLOWERS} ZK followers"
-              if [[ "${ZK_FOLLOWERS}" -gt "1" ]]; then
-                echo "ZK has two sync'd followers (with the leader that makes 3)"
+              echo "Checking for ZK readiness"
+              ZK_OK=$(echo ruok | nc {{ .Release.Name }}-zookeeper-headless.{{ .Release.Namespace }} 2181)
+              if [[ "${ZK_OK}" == "imok" ]]; then
+                echo "ZK reports ready and in good state"
                 exit 0
               fi
               sleep 1


### PR DESCRIPTION
# Problem

We've been facing intermittent failures with the existing method of checking Zookeeper cluster readiness within our init container in the StatefulSet. The init container was echoing the `mntr` command to port 2181 of the Zookeeper service and grepping for `zk_synced_followers`. However, this check only works if the service directs the request to the leader of the Zookeeper pods. If a follower pod responds, the `zk_synced_followers` parameter is not present, causing the check to fail erroneously.

# Solution

To address this issue, we're modifying the readiness check to echo the `ruok` command instead, and look for the `imok` response. This is the same method used in the Liveness and Readiness probes of the Zookeeper deployment.

This method of checking is more reliable and robust than the previous one, as it does not rely on the leader pod answering the readiness check and will work regardless of whether the service directs the request to the leader or a follower pod.

# Testing
The problem with Stardog sporadically not reaching a ready state in Kubernetes has been reported by various customers, most recently IDA.  I was easily able to reproduce the problem in my own k3s cluster as well as an Azure AKE cluster.  This fix has been tested successfully in both k8s distributions with both 'Parallel' and 'OrderedReady' pod manangement policy.  
