### PR TITLE
Remove erroneous key in deployment template

### DIFF
--- a/charts/stardog/templates/deployment.yaml
+++ b/charts/stardog/templates/deployment.yaml
@@ -12,7 +12,6 @@ metadata:
     app.kubernetes.io/component: client
 spec:
   replicas: 1
-  spec:
   selector:
     matchLabels:
       app: {{ include "stardog.fullname" . }}-launchpad


### PR DESCRIPTION
Helm complains about this erroneous extra `spec` key